### PR TITLE
Add @AuthnSkip decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,16 @@ collapses them into a single interceptor.
   its own.
 - `HttpAuthnInterceptor` inspects the controller and its handler. By default,
   _all endpoints_ require authentication, but you can decorate your handlers
-  with `@AuthnOptional()` to allow anonymous identities or with
-  `@AuthnDisallowed()` to _require_ them. If the handler's requirement matches
-  up with the identity on the request, the request continues; otherwise, the
-  response is a 401 Unauthorized.
+  with `@AuthnOptional()` to allow anonymous identities, with
+  `@AuthnDisallowed()` to _require_ them or with `@AuthnSkip()` to skip the checks entirely.
+  If the handler's requirement matches up with the identity on the request,
+  the request continues; otherwise, the response is a 401 Unauthorized.
+
+|| @AuthnRequired | @AuthnOptional | @AuthnDisallowed | @AuthnSkip |
+|-|-|-|-|-|
+| Good Auth |✅|✅|❌|✅|
+| Bad Auth  |❌|❌|❌|✅|
+| No Auth   |❌|✅|✅|✅|
 
 
 #### Authorization ####

--- a/src/authn/authn-optional.decorator.ts
+++ b/src/authn/authn-optional.decorator.ts
@@ -11,6 +11,9 @@ import { AuthnStatus } from './authn-status.enum';
  * The principal and credential are undefined; the scopes are whatever you've
  * set as the application's anonymous scopes.
  *
+ * This differs from `AuthSkip` in that if you send _bad_ auth,
+ * `AuthOptional` will fail and `AuthnSkip` will succeed
+ *
  * Formally, the @Identity parameter should take as a type something that looks
  * like `IdentityBill<TPrincipal, TCredential> | AnonymousBill`.
  */

--- a/src/authn/authn-skip.decorator.ts
+++ b/src/authn/authn-skip.decorator.ts
@@ -1,0 +1,17 @@
+import { SetMetadata } from '@nestjs/common';
+
+import { AUTHN_STATUS } from '../metadata-keys';
+import { AuthnStatus } from './authn-status.enum';
+
+/**
+ * Handlers decorated with `AuthnSkip` completely skip Authn entirely
+ * This is used for things that don't need any authentication checks at all
+ *
+ * This differs from `AuthOptional` in that if you send _bad_ auth,
+ * `AuthOptional` will fail and `AuthnSkip` will succeed
+ *
+ * Note that contexts are not loaded since we short-circuit, so youyou have to
+ * load all contexts manually in the Controller
+ */
+export const AuthnSkip = () =>
+    SetMetadata(AUTHN_STATUS, AuthnStatus.SKIP);

--- a/src/authn/authn-status.enum.ts
+++ b/src/authn/authn-status.enum.ts
@@ -2,4 +2,5 @@ export enum AuthnStatus {
   REQUIRED = 'required',
   OPTIONAL = 'optional',
   DISALLOWED = 'disallowed',
+  SKIP = 'skip',
 }


### PR DESCRIPTION
This PR adds an `@AuthnSkip` decorator that we can use for completely ignoring authn. Should only be used for completely public endpoints.